### PR TITLE
Fix tests

### DIFF
--- a/registry/endpoint_test.go
+++ b/registry/endpoint_test.go
@@ -8,8 +8,11 @@ func TestEndpointParse(t *testing.T) {
 		expected string
 	}{
 		{IndexServerAddress(), IndexServerAddress()},
-		{"http://0.0.0.0:5000", "http://0.0.0.0:5000/v1/"},
-		{"0.0.0.0:5000", "https://0.0.0.0:5000/v1/"},
+		{REGISTRYSERVER, REGISTRYSERVER},
+		{"http://0.0.0.0:5000/v1/", "http://0.0.0.0:5000/v1/"},
+		{"http://0.0.0.0:5000/v2/", "http://0.0.0.0:5000/v2/"},
+		{"http://0.0.0.0:5000", "http://0.0.0.0:5000/v0/"},
+		{"0.0.0.0:5000", "https://0.0.0.0:5000/v0/"},
 	}
 	for _, td := range testData {
 		e, err := newEndpoint(td.str, insecureRegistries)

--- a/utils/jsonmessage_test.go
+++ b/utils/jsonmessage_test.go
@@ -30,7 +30,7 @@ func TestProgress(t *testing.T) {
 	}
 
 	// this number can't be negetive gh#7136
-	expected = "[==============================================================>]     50 B/40 B"
+	expected = "[==================================================>]     50 B/40 B"
 	jp4 := JSONProgress{Current: 50, Total: 40}
 	if jp4.String() != expected {
 		t.Fatalf("Expected %q, got %q", expected, jp4.String())


### PR DESCRIPTION
Fixes the unit tests, assuming the behavior change is accurate.  Changing to use the REGISTRY endpoint to v2 breaks the integration tests since the latest version of the registry is not deployed.
