### PR TITLE
Add Tarsum Calculation during v2 Pull operation

### DIFF
--- a/pkg/tarsum/tarsum.go
+++ b/pkg/tarsum/tarsum.go
@@ -3,8 +3,11 @@ package tarsum
 import (
 	"bytes"
 	"compress/gzip"
+	"crypto"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
+	"fmt"
 	"hash"
 	"io"
 	"strings"
@@ -37,6 +40,30 @@ func NewTarSumHash(r io.Reader, dc bool, v Version, tHash THash) (TarSum, error)
 	ts := &tarSum{Reader: r, DisableCompression: dc, tarSumVersion: v, headerSelector: headerSelector, tHash: tHash}
 	err = ts.initTarSum()
 	return ts, err
+}
+
+// Create a new TarSum using the provided TarSum version+hash label.
+func NewTarSumForLabel(r io.Reader, disableCompression bool, label string) (TarSum, error) {
+	parts := strings.SplitN(label, "+", 2)
+	if len(parts) != 2 {
+		return nil, errors.New("tarsum label string should be of the form: {tarsum_version}+{hash_name}")
+	}
+
+	versionName, hashName := parts[0], parts[1]
+
+	version, ok := tarSumVersionsByName[versionName]
+	if !ok {
+		return nil, fmt.Errorf("unknown TarSum version name: %q", versionName)
+	}
+
+	hashConfig, ok := standardHashConfigs[hashName]
+	if !ok {
+		return nil, fmt.Errorf("unknown TarSum hash name: %q", hashName)
+	}
+
+	tHash := NewTHash(hashConfig.name, hashConfig.hash.New)
+
+	return NewTarSumHash(r, disableCompression, version, tHash)
 }
 
 // TarSum is the generic interface for calculating fixed time
@@ -88,6 +115,18 @@ type THash interface {
 func NewTHash(name string, h func() hash.Hash) THash {
 	return simpleTHash{n: name, h: h}
 }
+
+type tHashConfig struct {
+	name string
+	hash crypto.Hash
+}
+
+var (
+	standardHashConfigs = map[string]tHashConfig{
+		"sha256": {name: "sha256", hash: crypto.SHA256},
+		"sha512": {name: "sha512", hash: crypto.SHA512},
+	}
+)
 
 // TarSum default is "sha256"
 var DefaultTHash = NewTHash("sha256", sha256.New)

--- a/pkg/tarsum/versioning.go
+++ b/pkg/tarsum/versioning.go
@@ -31,11 +31,18 @@ func GetVersions() []Version {
 	return v
 }
 
-var tarSumVersions = map[Version]string{
-	Version0:   "tarsum",
-	Version1:   "tarsum.v1",
-	VersionDev: "tarsum.dev",
-}
+var (
+	tarSumVersions = map[Version]string{
+		Version0:   "tarsum",
+		Version1:   "tarsum.v1",
+		VersionDev: "tarsum.dev",
+	}
+	tarSumVersionsByName = map[string]Version{
+		"tarsum":     Version0,
+		"tarsum.v1":  Version1,
+		"tarsum.dev": VersionDev,
+	}
+)
 
 func (tsv Version) String() string {
 	return tarSumVersions[tsv]


### PR DESCRIPTION
While the v2 pull operation is writing the body of the layer blob to disk
it now computes the tarsum checksum of the archive before extracting it to
the backend storage driver. If the checksum does not match that from the
image manifest an error is raised.

Also adds more debug logging to the pull operation and fixes existing test
cases which were failing.

Docker-DCO-1.1-Signed-off-by: Josh Hawn josh.hawn@docker.com (github: jlhawn)
