### PR TITLE
Cleanup v2 session to require endpoint

### DIFF
--- a/graph/pull.go
+++ b/graph/pull.go
@@ -72,10 +72,6 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 		logName += ":" + tag
 	}
 
-	// Calling the v2 code path might change the session
-	// endpoint value, so save the original one!
-	originalSession := *r
-
 	if len(repoInfo.Index.Mirrors) == 0 && (repoInfo.Index.Official || endpoint.Version == registry.APIVersion2) {
 		j := job.Eng.Job("trust_update_base")
 		if err = j.Run(); err != nil {
@@ -94,8 +90,6 @@ func (s *TagStore) CmdPull(job *engine.Job) engine.Status {
 
 		log.Debug("image does not exist on v2 registry, falling back to v1")
 	}
-
-	r = &originalSession
 
 	log.Debugf("pulling v1 repository with local name %q", repoInfo.LocalName)
 	if err = s.pullRepository(r, job.Stdout, repoInfo, tag, sf, job.GetenvBool("parallel")); err != nil {

--- a/graph/push.go
+++ b/graph/push.go
@@ -199,7 +199,11 @@ func (s *TagStore) pushV2Repository(r *registry.Session, eng *engine.Engine, out
 		}
 	}
 
-	auth, err := r.GetV2Authorization(repoInfo.RemoteName, false)
+	endpoint, err := r.V2RegistryEndpoint(repoInfo.Index)
+	if err != nil {
+		return fmt.Errorf("error getting registry endpoint: %s", err)
+	}
+	auth, err := r.GetV2Authorization(endpoint, repoInfo.RemoteName, false)
 	if err != nil {
 		return fmt.Errorf("error getting authorization: %s", err)
 	}
@@ -269,13 +273,13 @@ func (s *TagStore) pushV2Repository(r *registry.Session, eng *engine.Engine, out
 		}
 
 		// Call mount blob
-		exists, err := r.PostV2ImageMountBlob(repoInfo.RemoteName, sumParts[0], manifestSum, auth)
+		exists, err := r.HeadV2ImageBlob(endpoint, repoInfo.RemoteName, sumParts[0], manifestSum, auth)
 		if err != nil {
 			out.Write(sf.FormatProgress(utils.TruncateID(img.ID), "Image push failed", nil))
 			return err
 		}
 		if !exists {
-			err = r.PutV2ImageBlob(repoInfo.RemoteName, sumParts[0], manifestSum, utils.ProgressReader(arch, int(img.Size), out, sf, false, utils.TruncateID(img.ID), "Pushing"), auth)
+			err = r.PutV2ImageBlob(endpoint, repoInfo.RemoteName, sumParts[0], manifestSum, utils.ProgressReader(arch, int(img.Size), out, sf, false, utils.TruncateID(img.ID), "Pushing"), auth)
 			if err != nil {
 				out.Write(sf.FormatProgress(utils.TruncateID(img.ID), "Image push failed", nil))
 				return err
@@ -287,7 +291,7 @@ func (s *TagStore) pushV2Repository(r *registry.Session, eng *engine.Engine, out
 	}
 
 	// push the manifest
-	return r.PutV2ImageManifest(repoInfo.RemoteName, tag, bytes.NewReader([]byte(manifestBytes)), auth)
+	return r.PutV2ImageManifest(endpoint, repoInfo.RemoteName, tag, bytes.NewReader([]byte(manifestBytes)), auth)
 }
 
 // FIXME: Allow to interrupt current push when new push of same image is done.


### PR DESCRIPTION
Another cleanup PR to move the endpoint logic up to the pull and push logic. This will allow the push and pull determining the endpoint and paves the way for allowing to do mirroring.

ping @jlhawn 