### PR TITLE
V2 registry fallback

### DIFF
--- a/graph/push.go
+++ b/graph/push.go
@@ -383,7 +383,7 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 
 	// Set a header so remotes can identify the command being carried out. If
 	// present, the remote may act on the field but this is mostly advisory.
-	metaHeaders["Docker-Command"] = "push"
+	metaHeaders["Docker-Command"] = []string{"push"}
 
 	if _, err := s.poolAdd("push", repoInfo.LocalName); err != nil {
 		return job.Error(err)

--- a/graph/push.go
+++ b/graph/push.go
@@ -385,6 +385,8 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 	// present, the remote may act on the field but this is mostly advisory.
 	metaHeaders["Docker-Command"] = []string{"push"}
 
+	repoInfo.Index.Headers = metaHeaders
+
 	if _, err := s.poolAdd("push", repoInfo.LocalName); err != nil {
 		return job.Error(err)
 	}

--- a/graph/push.go
+++ b/graph/push.go
@@ -381,6 +381,10 @@ func (s *TagStore) CmdPush(job *engine.Job) engine.Status {
 	job.GetenvJson("authConfig", authConfig)
 	job.GetenvJson("metaHeaders", &metaHeaders)
 
+	// Set a header so remotes can identify the command being carried out. If
+	// present, the remote may act on the field but this is mostly advisory.
+	metaHeaders["Docker-Command"] = "push"
+
 	if _, err := s.poolAdd("push", repoInfo.LocalName); err != nil {
 		return job.Error(err)
 	}

--- a/registry/session_v2.go
+++ b/registry/session_v2.go
@@ -22,7 +22,7 @@ func getV2Builder(e *Endpoint) *v2.URLBuilder {
 func (r *Session) V2RegistryEndpoint(index *IndexInfo) (ep *Endpoint, err error) {
 	// TODO check if should use Mirror
 	if index.Official {
-		ep, err = newEndpoint(REGISTRYSERVER, true)
+		ep, err = newEndpoint(REGISTRYSERVER, index.Secure, index.Headers)
 		if err != nil {
 			return
 		}
@@ -221,6 +221,12 @@ func (r *Session) PutV2ImageBlob(ep *Endpoint, imageName, sumType, sumStr string
 	res, _, err := r.doRequest(req)
 	if err != nil {
 		return err
+	}
+	if res.StatusCode != 202 {
+		if res.StatusCode == 401 {
+			return errLoginRequired
+		}
+		return utils.NewHTTPRequestError(fmt.Sprintf("Server error: %d trying to push %s blob", res.StatusCode, imageName), res)
 	}
 	location := res.Header.Get("Location")
 

--- a/registry/types.go
+++ b/registry/types.go
@@ -98,6 +98,7 @@ type IndexInfo struct {
 	Mirrors  []string
 	Secure   bool
 	Official bool
+	Headers  map[string][]string
 }
 
 type RepositoryInfo struct {


### PR DESCRIPTION
Add support for fallback to v1 on push

An HTTP header "Docker-Command" is added to specify the command as "push".  When the server returns a 404 from the v2 endpoint, the client should fallback to v1 and push to the v1 endpoint.
