### PR TITLE
Remove Checksum field from image.Image struct

### DIFF
--- a/graph/service.go
+++ b/graph/service.go
@@ -151,7 +151,6 @@ func (s *TagStore) CmdLookup(job *engine.Job) engine.Status {
 		out.Set("Os", image.OS)
 		out.SetInt64("Size", image.Size)
 		out.SetInt64("VirtualSize", image.GetParentsSize(0)+image.Size)
-		out.Set("Checksum", image.Checksum)
 		if _, err = out.WriteTo(job.Stdout); err != nil {
 			return job.Error(err)
 		}

--- a/image/image.go
+++ b/image/image.go
@@ -31,7 +31,6 @@ type Image struct {
 	Config          *runconfig.Config `json:"config,omitempty"`
 	Architecture    string            `json:"architecture,omitempty"`
 	OS              string            `json:"os,omitempty"`
-	Checksum        string            `json:"checksum"`
 	Size            int64
 
 	graph Graph


### PR DESCRIPTION
The checksum is now being stored in a separate file beside the image
JSON file.

Docker-DCO-1.1-Signed-off-by: Josh Hawn <josh.hawn@docker.com> (github: jlhawn)