### PR TITLE
Enforce our use of the explicitly frozen images

### DIFF
--- a/hack/make/.ensure-frozen-images
+++ b/hack/make/.ensure-frozen-images
@@ -11,10 +11,10 @@ if ! docker inspect "${images[@]}" &> /dev/null; then
 	hardCodedDir='/docker-frozen-images'
 	if [ -d "$hardCodedDir" ]; then
 		( set -x; tar -cC "$hardCodedDir" . | docker load )
-	elif [ -e Dockerfile ] && command -v curl > /dev/null; then
-		# testing for "curl" because "download-frozen-image.sh" is built around curl
+	else
 		dir="$DEST/frozen-images"
 		# extract the exact "RUN download-frozen-image.sh" line from the Dockerfile itself for consistency
+		# NOTE: this will fail if either "curl" is not installed or if the Dockerfile is not available/readable
 		awk '
 			$1 == "RUN" && $2 == "./contrib/download-frozen-image.sh" {
 				for (i = 2; i < NF; i++)
@@ -33,11 +33,5 @@ if ! docker inspect "${images[@]}" &> /dev/null; then
 			}
 		' Dockerfile | sh -x
 		( set -x; tar -cC "$dir" . | docker load )
-	else
-		for image in "${images[@]}"; do
-			if ! docker inspect "$image" &> /dev/null; then
-				( set -x; docker pull "$image" )
-			fi
-		done
 	fi
 fi


### PR DESCRIPTION
This requires that any environment where we wish to run the integration-cli tests includes both the `Dockerfile` and `curl`, which has been deemed an appropriate and acceptable trade-off.